### PR TITLE
Overwrite Mac binaries with ad hoc signature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'edu.wpi.first'
-version '0.7.0'
+version '0.7.1'
 
 if (project.hasProperty('publishVersion')) {
     version = project.publishVersion

--- a/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
+++ b/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
@@ -126,7 +126,7 @@ public class FixupNativeResources extends DefaultTask {
 
                 // Overwrite signature because they were invalidated by strip and install-name-tool.
                 project.exec((ex) -> {
-                    ex.commandLine("sh", "-c", "codesign --force --strict --timestamp --options=runtime --sign - " + 
+                    ex.commandLine("sh", "-c", "codesign --force --sign - " + 
                                    file.toString());
                     ex.setStandardOutput(standardOutput);
                 });

--- a/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
+++ b/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
@@ -123,6 +123,13 @@ public class FixupNativeResources extends DefaultTask {
                                 file.toString());
                     });
                 }
+
+                // Overwrite signature because they were invalidated by strip and install-name-tool.
+                project.exec((ex) -> {
+                    ex.commandLine("sh", "-c", "codesign --force --strict --timestamp --options=runtime --sign - " + 
+                                   file.toString());
+                    ex.setStandardOutput(standardOutput);
+                });
             }
         }
     }

--- a/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
+++ b/src/main/java/edu/wpi/first/tools/FixupNativeResources.java
@@ -126,8 +126,7 @@ public class FixupNativeResources extends DefaultTask {
 
                 // Overwrite signature because they were invalidated by strip and install-name-tool.
                 project.exec((ex) -> {
-                    ex.commandLine("sh", "-c", "codesign --force --sign - " + 
-                                   file.toString());
+                    ex.commandLine("codesign", "--force", "--sign",  "-", file.toString());
                     ex.setStandardOutput(standardOutput);
                 });
             }


### PR DESCRIPTION
This fixes all extraction issues on Mac with our new signed binaries.