### PR TITLE
Fix Crash When Used in Multiple Subprojects on Windows

### DIFF
--- a/src/main/java/edu/wpi/first/tools/ExtractConfiguration.java
+++ b/src/main/java/edu/wpi/first/tools/ExtractConfiguration.java
@@ -102,7 +102,7 @@ public class ExtractConfiguration extends DefaultTask {
         views = new ArrayList<>();
 
         if (OperatingSystem.current().isWindows()) {
-            TaskProvider<Task> extractTask = getProject().getRootProject().getTasks()
+            TaskProvider<Task> extractTask = getProject().getTasks()
                     .named("extractEmbeddedWindowsHelpers");
 
             dependsOn(extractTask);

--- a/src/main/java/edu/wpi/first/tools/WpilibTools.java
+++ b/src/main/java/edu/wpi/first/tools/WpilibTools.java
@@ -16,9 +16,9 @@ public class WpilibTools implements Plugin<Project> {
         if (OperatingSystem.current().isWindows()) {
             var extractTaskName = "extractEmbeddedWindowsHelpers";
             try {
-                project.getRootProject().getTasks().named(extractTaskName);
+                project.getTasks().named(extractTaskName);
             } catch (UnknownTaskException notfound) {
-                project.getRootProject().getTasks().register(extractTaskName, ExtractEmbeddedWindowsHelpers.class);
+                project.getTasks().register(extractTaskName, ExtractEmbeddedWindowsHelpers.class);
             }
         }
 


### PR DESCRIPTION
If this plugin is used in multiple subprojects, and at least one of these subprojects is using the shadow jar plugin ([as recommended by wpilib](https://docs.wpilib.org/en/latest/docs/software/networktables/client-side-program.html)), the build fails on Windows. This is because the shadow jar plugin causes each subproject to build with a different class loader. Thus, WpilibTools is loaded twice. The first version of WpilibTools registers an instance of `ExtractEmbeddedWindowsHelpers` on the root project. When the second submodule attempts to query the output of the task, it attempts to cast the generalized `Task` to an instance of `ExtractEmbeddedWindowsHelpers`. However, because the instance of the task was loaded from a different class loader, the cast fails with the error
`class edu.wpi.first.tools.ExtractEmbeddedWindowsHelpers_Decorated cannot be cast to class edu.wpi.first.tools.ExtractEmbeddedWindowsHelpers (edu.wpi.first.tools.ExtractEmbeddedWindowsHelpers_Decorated is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @<hash>; edu.wpi.first.tools.ExtractEmbeddedWindowsHelpers is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @<hash>)`.

As a workaround,
``` Groovy
id 'edu.wpi.first.WpilibTools' version '1.3.0'
```
can be added to the `plugins` block of the root project. This loads the plugin as part of the root project (which, I'm guessing, is a classloader which is parent of the classloaders used in the subprojects. Thus, the plugin is only loaded once, so the cast is successful.

This PR adds the task to the subprojects rather than the root project, fixing the crash. I also considered removing the cast and just doing `resolvedExtractTask.getOutputs()`, but in the unlikely case that different versions of this extension are used in the subprojects, it may, in fact, be desirable to run the task twice to get different versions of the windows helpers for each build.

For testing purposes, I've also created [a sample project (zip)](https://github.com/user-attachments/files/15878347/sample-project.zip) that can be used to demonstrate this error.