### PR TITLE
Only add resources for the intended platform

### DIFF
--- a/src/main/java/edu/wpi/first/tools/ExtractConfiguration.java
+++ b/src/main/java/edu/wpi/first/tools/ExtractConfiguration.java
@@ -95,14 +95,19 @@ public class ExtractConfiguration extends DefaultTask {
     @TaskAction
     public void execute() throws IOException {
 
+        // Parse wpilib classifier to get the path
+        String wpilibPlat = getProject().getExtensions().getByType(WpilibToolsExtension.class).getPlatformMapper().getWpilibClassifier();
+
+        String platPath = wpilibPlat.replace("linux", "linux/").replace("win", "windows/").replace("mac", "macosx/") + "/";
+
         getProject().copy(spec -> {
             spec.into(outputDirectory);
             spec.from(configurations);
 
-            spec.include("**/*.so");
-            spec.include("**/*.so.*");
-            spec.include("**/*.dll");
-            spec.include("**/*.dylib");
+            spec.include(platPath + "**/*.so");
+            spec.include(platPath + "**/*.so.*");
+            spec.include(platPath + "**/*.dll");
+            spec.include(platPath + "**/*.dylib");
 
             spec.exclude("**/*.so.debug");
         });


### PR DESCRIPTION
Previously, when we built, we added all the native resources that had been downloaded. This means that if we build a jar for `arm64` we also toss in everything from `x86-64` if we'd built that jar before and hadn't cleaned the gradle cache since. This picks only the files for the platform we want to use. Still needs testing.